### PR TITLE
Potential fix for code scanning alert no. 23: Use of externally-controlled format string

### DIFF
--- a/server/routes/posts.ts
+++ b/server/routes/posts.ts
@@ -1256,7 +1256,7 @@ const deletePostMediaFiles = async (postId: string): Promise<void> => {
       console.log(`Deleted media directory for post: ${postId}`);
     }
   } catch (error) {
-    console.error(`Failed to delete media files for post ${postId}:`, error);
+    console.error('Failed to delete media files for post:', postId, error);
   }
 };
 


### PR DESCRIPTION
Potential fix for [https://github.com/axiorissocial/web/security/code-scanning/23](https://github.com/axiorissocial/web/security/code-scanning/23)

To fix this issue, untrusted data should not be interpolated into the template string (which acts as a format string in some loggers). Instead, the log message should use a static string with a placeholder (such as `%s` for strings), passing the untrusted user input as a parameter, or, in the case of `console.error` in Node.js (which automatically prints extra arguments after the first), simply use a comma to separate the static message from the user-controlled data. This preserves correct and readable logs and prevents unintended format-string bugs.

**Edit file:** `server/routes/posts.ts`  
**Region:** Line 1259 (`console.error(...)`)  
**What to change:**  
- Change:  
  ```js
  console.error(`Failed to delete media files for post ${postId}:`, error);
  ```
  To:  
  ```js
  console.error('Failed to delete media files for post:', postId, error);
  ```
There are no additional dependencies or imports needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
