### PR TITLE
Potential fix for code scanning alert no. 5: Uncontrolled data used in path expression

### DIFF
--- a/server/routes/account.ts
+++ b/server/routes/account.ts
@@ -3,6 +3,8 @@ import bcrypt from 'bcrypt';
 import multer from 'multer';
 import path from 'path';
 import fs from 'fs';
+
+const AVATARS_DIR = path.join(process.cwd(), 'public', 'uploads', 'avatars');
 import { PrismaClient } from '../../src/generated/prisma/index.js';
 
 const router = express.Router();
@@ -224,8 +226,10 @@ router.post('/users/profile/avatar', requireAuth, upload.single('avatar'), async
     
     if (req.file) {
       const filePath = req.file.path;
-      if (fs.existsSync(filePath)) {
-        fs.unlinkSync(filePath);
+      // Validate and restrict file deletion to AVATARS_DIR only
+      const resolvedPath = path.resolve(filePath);
+      if (resolvedPath.startsWith(AVATARS_DIR) && fs.existsSync(resolvedPath)) {
+        fs.unlinkSync(resolvedPath);
       }
     }
     


### PR DESCRIPTION
Potential fix for [https://github.com/axiorissocial/web/security/code-scanning/5](https://github.com/axiorissocial/web/security/code-scanning/5)

The recommended fix is to validate the constructed file path before using it with `fs.unlinkSync`. Specifically, when attempting to delete an uploaded file (in the catch block), we should ensure that the file is in the intended avatars directory and not pointing elsewhere on the file system due to any possible manipulation. We can achieve this by normalizing and resolving the path, and restricting deletions to files only within the `/public/uploads/avatars` directory. This involves:
- Resolving the user-provided path to an absolute path.
- Verifying that the resolved path starts with the absolute path of the intended avatars directory.
- Only deleting the file if both conditions are met.

The changes are localized to the catch block in the `router.post('/users/profile/avatar', ...)` handler in `server/routes/account.ts`, specifically lines 226–229. We should also define a constant for the uploads avatars directory at the top of the file to ensure consistency and avoid duplication.

**Required updates:**
- Add a constant at the top for the absolute avatars directory.
- In the catch block, resolve `filePath`, check if it's under the allowed directory, and only then delete.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
