### PR TITLE
Potential fix for code scanning alert no. 29: Use of externally-controlled format string

### DIFF
--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -14,7 +14,7 @@ const deletePostMediaFiles = async (postId: string) => {
       console.log(`Deleted media directory for post: ${postId}`);
     }
   } catch (error) {
-    console.error(`Failed to delete media for post ${postId}:`, error);
+    console.error('Failed to delete media for post %s:', postId, error);
   }
 };
 


### PR DESCRIPTION
Potential fix for [https://github.com/axiorissocial/web/security/code-scanning/29](https://github.com/axiorissocial/web/security/code-scanning/29)

To resolve the issue, the log message construction on line 17 should avoid interpolating the user-controlled value directly into the template string. Instead, use a static string with a `%s` specifier and supply the untrusted value as an argument to `console.error`. This way, even if the user-supplied value contains format specifiers, it will be safely handled as a string. Only line 17 in `deletePostMediaFiles` needs to be changed. No new imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
