### PR TITLE
Potential fix for code scanning alert no. 27: Uncontrolled data used in path expression

### DIFF
--- a/server/utils/videoProcessor.ts
+++ b/server/utils/videoProcessor.ts
@@ -279,16 +279,24 @@ export class VideoProcessor {
 
   static async cleanupVideoFiles(mediaDir: string): Promise<void> {
     try {
-      const exists = await fs.pathExists(mediaDir);
+      const ROOT_MEDIA_DIR = path.resolve(process.cwd(), 'public', 'uploads', 'media');
+      const resolvedMediaDir = path.resolve(mediaDir);
+      // Ensure the directory is within the allowed media root directory
+      if (!resolvedMediaDir.startsWith(ROOT_MEDIA_DIR + path.sep)) {
+        console.error('Refusing to clean up files for mediaDir outside allowed directory:', resolvedMediaDir);
+        return;
+      }
+
+      const exists = await fs.pathExists(resolvedMediaDir);
       if (!exists) return;
 
-      const files = await fs.readdir(mediaDir);
+      const files = await fs.readdir(resolvedMediaDir);
       const removableExtensions = ['.m3u8', '.ts'];
 
       await Promise.all(
         files
           .filter(file => removableExtensions.includes(path.extname(file).toLowerCase()))
-          .map(file => fs.remove(path.join(mediaDir, file)).catch(() => undefined))
+          .map(file => fs.remove(path.join(resolvedMediaDir, file)).catch(() => undefined))
       );
     } catch (error) {
       console.error('Error cleaning up video files:', error);


### PR DESCRIPTION
Potential fix for [https://github.com/axiorissocial/web/security/code-scanning/27](https://github.com/axiorissocial/web/security/code-scanning/27)

The best mitigation is to ensure that the constructed path always stays within the intended root directory. For this scenario, this means ensuring that `mediaDir` must ALWAYS be under `public/uploads/media`. This can be done by:
- Constructing the full resolved path using `path.resolve`.
- Comparing (after resolving) to ensure that the path starts with the intended root (also resolved).

Specifically, in `cleanupVideoFiles(mediaDir: string)`, before proceeding, resolve `mediaDir` and check that it is in the intended directory. If it is not, do not proceed with deletion.

Because the function receives `mediaDir`, and validation is desirable at the boundary or as soon as possible after receiving the untrusted value, the validation should be added at the beginning of `cleanupVideoFiles`.

We'll need to add logic at the top of `cleanupVideoFiles` (in `server/utils/videoProcessor.ts`, lines 280–296).

We'll use Node's `path` module to resolve and ensure that `mediaDir` starts with the correct prefix (i.e., the root uploads/media directory). We'll define this root inline for clarity as `ROOT_MEDIA_DIR` using `path.resolve(process.cwd(), 'public', 'uploads', 'media')`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
