### PR TITLE
Potential fix for code scanning alert no. 26: Uncontrolled data used in path expression

### DIFF
--- a/server/routes/posts.ts
+++ b/server/routes/posts.ts
@@ -1359,6 +1359,11 @@ router.get('/posts/:postId/media/:mediaIndex/download', requireAuth, async (req:
 
 const deletePostMediaFiles = async (postId: string): Promise<void> => {
   try {
+    // Validate postId format to prevent path traversal and filesystem attack
+    const SAFE_ID_REGEX = /^[a-zA-Z0-9_-]+$/;
+    if (!SAFE_ID_REGEX.test(postId)) {
+      throw new Error(`Invalid postId format: ${postId}`);
+    }
     const mediaDir = path.join(process.cwd(), 'public', 'uploads', 'media', postId);
     
     if (fs.existsSync(mediaDir)) {


### PR DESCRIPTION
Potential fix for [https://github.com/axiorissocial/web/security/code-scanning/26](https://github.com/axiorissocial/web/security/code-scanning/26)

To fix this problem, we need to ensure that user-supplied data (`postId`) used as a path component is properly validated or sanitized before being incorporated into a filesystem path. The best way in this context is to ensure that `postId` cannot contain path traversal elements (e.g., "../" or "/"), and is strictly a valid identifier (such as a UUID or database ID) without any path components. One suitable method is to validate that `postId` matches the expected format (e.g., a UUID v4 regex pattern or a database id format), and to reject requests with invalid formats. Alternatively, paths constructed with potentially user-supplied values should be normalized and checked to ensure they reside within the allowed root directory.

For this codebase, the safest solution is to ensure `postId` matches a strict pattern (such as `/^[a-zA-Z0-9_-]+$/`, which will block "/", "\", and "." characters), before paths are constructed/used. This validation should be placed near the point of input (i.e., in the `deletePostMediaFiles` method and/or at the route). If invalid, respond with 400 Bad Request. This ensures that the directory access and deletion code will never have the opportunity to operate outside the intended directory tree, even for malicious requests.

The following changes are needed:
- At the start of `deletePostMediaFiles`, add a check for postId against a safe regex and abort if invalid.
- Optionally, this check can also be done in the route handler (double validation), but at minimum it should be placed where the filesystem path is built (the lowest point shown).

No new methods or imports are needed, just a line for regex definition and a conditional logic block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
