### PR TITLE
Potential fix for code scanning alert no. 30: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "sass": "^1.93.2",
     "session-file-store": "^1.5.0",
     "twemoji": "^14.0.2",
-    "ws": "^8.18.0"
+    "ws": "^8.18.0",
+    "express-rate-limit": "^8.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",


### PR DESCRIPTION
Potential fix for [https://github.com/axiorissocial/web/security/code-scanning/30](https://github.com/axiorissocial/web/security/code-scanning/30)

To fix the problem, introduce rate limiting to the `/users/profile/gradients` route handler by adding a dedicated rate-limit middleware. The recommended approach is to use the well-known `express-rate-limit` package. Add the required import at the top of the file, configure a reasonable rate limiter (for example, max 5 requests per minute per user), and apply it specifically to the `/users/profile/gradients` route, so only requests to this endpoint are affected. Make sure the limiter is applied before authentication and the route handler itself. Changes are limited to server/routes/account.ts, adding the import, the limiter definition, and updating the router definition for this endpoint.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
